### PR TITLE
If no IPv4 can be found use IPv6

### DIFF
--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -1053,7 +1053,13 @@ def create(vm_):
         try:
             private_ip = data['private_ips'][0]
         except KeyError:
-            private_ip = data['template']['nic']['ip']
+            try:
+                private_ip = data['template']['nic']['ip']
+            except:
+                # if IPv6 is used try this as last resort
+                # OpenNebula does not yet show ULA address here so take global
+                private_ip = data['template']['nic']['ip6_global']
+
             vm_['ssh_host'] = private_ip
 
     ssh_username = config.get_cloud_config_value(


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

As IPv4 addresses delivered by DHCP server never are known to OpenNebula and thus SaltStack I give the VM an IPv6 address which then can be used by salt-cloud.